### PR TITLE
Improve performance and memory usage of decryption

### DIFF
--- a/server/services/service.ts
+++ b/server/services/service.ts
@@ -72,13 +72,12 @@ export default ({ strapi }: { strapi: Strapi }) => ({
   decrypt(value: string): string {
     if (!value) return value;
 
-    const textParts = value.split(':');
-    const firstPart = textParts.shift();
+    const dotsPos = value.indexOf(':');
 
     if (!firstPart) throw new Error('Malformed payload');
 
-    const iv = Buffer.from(firstPart, 'hex');
-    const encryptedText = Buffer.from(textParts.join(':'), 'hex');
+    const iv = Buffer.from(value.slice(0, dotsPos), 'hex');
+    const encryptedText = Buffer.from(value.slice(dotsPos + 1), 'hex');
     const decipher = createDecipheriv(AES_METHOD, Buffer.from(KEY), iv);
 
     let decrypted = decipher.update(encryptedText);

--- a/server/services/service.ts
+++ b/server/services/service.ts
@@ -37,12 +37,11 @@ export default ({ strapi }: { strapi: Strapi }) => ({
   isEncrypted(value: string): boolean {
     if (!value) return false;
 
-    const textParts = value.split(':');
-    const firstPart = textParts.shift();
+    const dotsPos = value.indexOf(':');
 
-    if (!firstPart) throw new Error('Malformed payload');
+    if (dotsPos < 0) throw new Error('Malformed payload');
 
-    const iv = Buffer.from(firstPart, 'hex');
+    const iv = Buffer.from(value.slice(0, dotsPos), 'hex');
 
     // Test first indications of encrypted or not
     if (iv.length !== IV_LENGTH && !/[0-9A-Fa-f]{6}/g.test(value)) {
@@ -74,7 +73,7 @@ export default ({ strapi }: { strapi: Strapi }) => ({
 
     const dotsPos = value.indexOf(':');
 
-    if (!firstPart) throw new Error('Malformed payload');
+    if (dotsPos < 0) throw new Error('Malformed payload');
 
     const iv = Buffer.from(value.slice(0, dotsPos), 'hex');
     const encryptedText = Buffer.from(value.slice(dotsPos + 1), 'hex');


### PR DESCRIPTION
With the usage of split the encrypted value was duplicated 3 times in memory (Once in value, once in the parts, and once in the buffer)

With this change it should only be held in the value and the buffers

It's a minimal performance improvement as well but since it's in a critical part as it can be called several hundreds of times if you have a lot of records a few performance improvements should be welcome

A [quick benchmark](https://jsben.ch/Q8wAz) shows that the changed part (not the whole function) is now 40% faster