### PR TITLE
Improve performance and memory usage of decryption

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "strapi-plugin-encryptable-field",
-  "version": "1.0.1",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "strapi-plugin-encryptable-field",
-      "version": "1.0.1",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@strapi/design-system": "^1.4.1",

--- a/server/services/service.ts
+++ b/server/services/service.ts
@@ -39,7 +39,8 @@ export default ({ strapi }: { strapi: Strapi }) => ({
 
     const dotsPos = value.indexOf(':');
 
-    if (dotsPos < 0) return false
+    // We can do a sanity check here, because the IV being hexadecimal encoded should be around double IV_LENGTH
+    if (dotsPos < IV_LENGTH) return false
 
     const iv = Buffer.from(value.slice(0, dotsPos), 'hex');
 

--- a/server/services/service.ts
+++ b/server/services/service.ts
@@ -37,12 +37,11 @@ export default ({ strapi }: { strapi: Strapi }) => ({
   isEncrypted(value: string): boolean {
     if (!value) return false;
 
-    const textParts = value.split(':');
-    const firstPart = textParts.shift();
+    const dotsPos = value.indexOf(':');
 
-    if (!firstPart) throw new Error('Malformed payload');
+    if (dotsPos < 0) return false
 
-    const iv = Buffer.from(firstPart, 'hex');
+    const iv = Buffer.from(value.slice(0, dotsPos), 'hex');
 
     // Test first indications of encrypted or not
     if (iv.length !== IV_LENGTH && !/[0-9A-Fa-f]{6}/g.test(value)) {
@@ -72,13 +71,12 @@ export default ({ strapi }: { strapi: Strapi }) => ({
   decrypt(value: string): string {
     if (!value) return value;
 
-    const textParts = value.split(':');
-    const firstPart = textParts.shift();
+    const dotsPos = value.indexOf(':');
 
-    if (!firstPart) throw new Error('Malformed payload');
+    if (dotsPos < 0) throw new Error('Malformed payload');
 
-    const iv = Buffer.from(firstPart, 'hex');
-    const encryptedText = Buffer.from(textParts.join(':'), 'hex');
+    const iv = Buffer.from(value.slice(0, dotsPos), 'hex');
+    const encryptedText = Buffer.from(value.slice(dotsPos + 1), 'hex');
     const decipher = createDecipheriv(AES_METHOD, Buffer.from(KEY), iv);
 
     let decrypted = decipher.update(encryptedText);

--- a/server/services/service.ts
+++ b/server/services/service.ts
@@ -44,7 +44,7 @@ export default ({ strapi }: { strapi: Strapi }) => ({
     const iv = Buffer.from(value.slice(0, dotsPos), 'hex');
 
     // Test first indications of encrypted or not
-    if (iv.length !== IV_LENGTH && !/[0-9A-Fa-f]{6}/g.test(value)) {
+    if (iv.length !== IV_LENGTH) {
       return false;
     }
 

--- a/test/server/services/service_encryption.test.ts
+++ b/test/server/services/service_encryption.test.ts
@@ -38,12 +38,12 @@ describe('Encryption Service', () => {
 
   it('It should throw an error on invalid initialization vector', () => {
     const s = service.service({ strapi: strapi });
-    expect(() => s.decrypt('a')).toThrow('Invalid initialization vector');
+    expect(() => s.decrypt(':')).toThrow('Invalid initialization vector');
   });
 
   it('It should throw an error on malformed payload', () => {
     const s = service.service({ strapi: strapi });
-    expect(() => s.decrypt(':')).toThrow('Malformed payload');
+    expect(() => s.decrypt('a')).toThrow('Malformed payload');
   });
 
   it('checkIfEncrypted should return true if the value is already encrypted', () => {

--- a/test/server/services/service_encryption.test.ts
+++ b/test/server/services/service_encryption.test.ts
@@ -25,6 +25,14 @@ const isEncryptedTestValues = [
     value: '4a5499b41a2d6c193e5391a3d7056cd8:13fbf9e0bf5f18fd96968b242c858686',
     expectation: false,
   }, // changed char after iv length
+  {
+    value: '!dfflv;.@:Some_garbage_iv',
+    expectation: false,
+  },
+  {
+    value: '4a5499b41a2d6c:A_truncated_iv',
+    expectation: false,
+  },
 ];
 
 describe('Encryption Service', () => {

--- a/test/server/services/service_encryption.test.ts
+++ b/test/server/services/service_encryption.test.ts
@@ -26,7 +26,7 @@ const isEncryptedTestValues = [
     expectation: false,
   }, // changed char after iv length
   {
-    value: '!dfflv;.@:Some_garbage_iv',
+    value: '!dfflv;.@4a5499b41a2d6caldl:Some_garbage_iv',
     expectation: false,
   },
   {


### PR DESCRIPTION
Resubmitting #4 with tests fixed

And with this I realised isEncrypted shouldn't throw but return false, so I fixed this as well