### PR TITLE
docs: add command to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ module.exports = {
 
 Add the environment variable `ENCRYPTION_KEY` to your server and the .env.
 
+You can generate a key by running the following command in your terminal:
+
+```bash
+node -e "console.log(require('crypto').randomBytes(16).toString('hex'));"
+```
+
 ### Using the plugin
 
 After installation and configuration the custom field is ready to use.  


### PR DESCRIPTION
The command used to generate the encryption key was added to the docs.
It took me a minute to figure out how to get it, so I thought it would be nice to add it. Plus there was this issue as well #17 