### PR TITLE
README.md needs ```yarn build``` for smoother doc reading journey!

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ npm install strapi-plugin-encryptable-field
 
 # If you use Yarn
 yarn add strapi-plugin-encryptable-field
+
+# Then rebuild the UI if you use Yarn
+yarn build
 ```
 
 ### Configuring the plugin

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@strapi/strapi": "^4.4.0"
   },
   "engines": {
-    "node": ">=14.19.1 <=18.x.x",
+    "node": ">=14.19.1 <=21.x.x",
     "npm": ">=6.0.0"
   },
   "license": "MIT",


### PR DESCRIPTION
```yarn build``` was missing. 

This is my first time installing a custom input so I was thinking "What did I do wrong? I followed the instructions perfectly!". 

Turns out, I was supposed to run ```yarn build``` to make the input appear in the UI.

```yarn build``` works for yarn users, but I'm not sure if NPM users need to run ```npm run build``` to make the custom input appear in their UI.

Hopefully, someone can let me know if this is true for NPM users as well.

Here's a reference to the solution: https://stackoverflow.com/questions/74699819/strapi-custom-fields-not-showing-after-installing-plugin